### PR TITLE
run-dosbox.sh: fix XDG config path

### DIFF
--- a/run-dosbox.sh
+++ b/run-dosbox.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-CONF_PATH="${HOST_XDG_CONFIG_HOME:-${XDG_CONFIG_HOME:-$HOME/.config}}/dosbox/dosbox.conf"
+CONF_PATH="$XDG_CONFIG_HOME/dosbox/dosbox.conf"
 
 if [ -f "$CONF_PATH" ]; then
     exec dosbox -conf "$CONF_PATH" "$@"


### PR DESCRIPTION
I tested it and it's turned out $XDG_CONFIG_HOME is the only thing we should check, as flatpak cares about the rest.

- $HOME/.config is not needed and wrong, because $XDG_CONFIG_HOME is always set within flatpak and points to the right path.
  ~/.config has no special meaning in flatpak and doesn't exist.
- $HOST_XDG_CONFIG_HOME is not needed - if $XDG_CONFIG_HOME set on host side, it's directory just bind mounted in two places within the flatpak - by $XDG_CONFIG_HOME and $HOST_XDG_CONFIG_HOME.

PS:
Another words, whatever $XDG_CONFIG_HOME is set on host (if ever), it's corresponding $XDG_CONFIG_HOME in flatpak is stable (`~/.var/app/<app-id>/config`), and the directory contains a `path` pointing to actual data on host if `--filesystem=xdg-config/path` is overridden.